### PR TITLE
Added a temp FAQ page to redirect /vtl/faq to the new FAQ page

### DIFF
--- a/pages/Frequently Asked Questions.md
+++ b/pages/Frequently Asked Questions.md
@@ -3,3 +3,6 @@ title: Frequently Asked Questions
 permalink: /vtl/faq
 description: ""
 ---
+This page is no longer available. 
+
+The Frequently Asked Questions have been moved to **[this page](/faq)**.

--- a/pages/Frequently Asked Questions.md
+++ b/pages/Frequently Asked Questions.md
@@ -3,6 +3,6 @@ title: VTL - Frequently Asked Questions
 permalink: /vtl/faq
 description: ""
 ---
-This page is no longer available. 
+<b>This page is no longer available. </b>
 
 The Frequently Asked Questions have been moved to **[this page](/faq)**.

--- a/pages/Frequently Asked Questions.md
+++ b/pages/Frequently Asked Questions.md
@@ -1,5 +1,5 @@
 ---
-title: Frequently Asked Questions
+title: VTL - Frequently Asked Questions
 permalink: /vtl/faq
 description: ""
 ---

--- a/pages/Frequently Asked Questions.md
+++ b/pages/Frequently Asked Questions.md
@@ -1,0 +1,5 @@
+---
+title: Frequently Asked Questions
+permalink: /vtl/faq
+description: ""
+---


### PR DESCRIPTION
DXC will only deploy the changes to the links tonight. Will take down the temp FAQ page once deployed